### PR TITLE
bug/sc-43454/bbox-aggregation-does-not-work-on-geo-shapes

### DIFF
--- a/src/main/java/org/opendatasoft/elasticsearch/ingest/GeoExtensionProcessor.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/ingest/GeoExtensionProcessor.java
@@ -267,32 +267,19 @@ public class GeoExtensionProcessor extends AbstractProcessor {
             if (centroidField != null) ingestDocument.setFieldValue(
                     geoShapeField + "." + centroidField, GeoUtils.getCentroidFromGeom(geom));
             if (bboxField != null) {
-                Coordinate[] coords;
-                if (geom.getGeometryType() == "Point") {
-                    coords = geom.getCoordinates();
-                    if (coords.length == 1) {
-                        GeoPoint topLeft = new GeoPoint(
-                                org.elasticsearch.common.geo.GeoUtils.normalizeLat(coords[0].y),
-                                org.elasticsearch.common.geo.GeoUtils.normalizeLon(coords[0].x)
-                        );
-                        GeoPoint bottomRight = new GeoPoint(
-                                org.elasticsearch.common.geo.GeoUtils.normalizeLat(coords[0].y),
-                                org.elasticsearch.common.geo.GeoUtils.normalizeLon(coords[0].x)
-                        );
-
-                        ingestDocument.setFieldValue(
-                                geoShapeField + "." + bboxField,
-                                Arrays.asList(topLeft, bottomRight)
-                        );
-                    }
-                } else {
-                    coords = geom.getEnvelope().getCoordinates();
-                    if (coords.length >= 4) {
-                        ingestDocument.setFieldValue(
-                                geoShapeField + "." + bboxField,
-                                GeoUtils.getBboxFromCoords(coords)
-                        );
-                    }
+                Coordinate[] coords = geom.getEnvelope().getCoordinates();
+                if (coords.length >= 4) {
+                    ingestDocument.setFieldValue(
+                            geoShapeField + "." + bboxField,
+                            GeoUtils.getBboxFromCoords(coords));
+                } else if (coords.length == 1) {
+                    GeoPoint point = new GeoPoint(
+                            org.elasticsearch.common.geo.GeoUtils.normalizeLat(coords[0].y),
+                            org.elasticsearch.common.geo.GeoUtils.normalizeLon(coords[0].x)
+                    );
+                    ingestDocument.setFieldValue(
+                            geoShapeField + "." + bboxField,
+                            Arrays.asList(point, point));
                 }
             }
         }

--- a/src/yamlRestTest/resources/rest-api-spec/test/GeoExtension/20_geo_ingest_processor.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/GeoExtension/20_geo_ingest_processor.yml
@@ -165,6 +165,7 @@
               id: 2
 
   - match: {hits.hits.0._source.geo_shape_0.fixed_shape: "POINT (110.74218749999999 -82.16644600847728)"}
+  - match: {test_index.mappings.properties.geo_shape_0.properties.bbox.type: "geo_point"}
 
 # Test Linestring
   - do:

--- a/src/yamlRestTest/resources/rest-api-spec/test/GeoExtension/20_geo_ingest_processor.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/GeoExtension/20_geo_ingest_processor.yml
@@ -165,7 +165,10 @@
               id: 2
 
   - match: {hits.hits.0._source.geo_shape_0.fixed_shape: "POINT (110.74218749999999 -82.16644600847728)"}
-  - match: {test_index.mappings.properties.geo_shape_0.properties.bbox.type: "geo_point"}
+  - match: {hits.hits.0._source.geo_shape_0.bbox.0.lat: -82.16644600847728}
+  - match: {hits.hits.0._source.geo_shape_0.bbox.0.lon: 110.74218749999999}
+  - match: {hits.hits.0._source.geo_shape_0.bbox.1.lat: -82.16644600847728}
+  - match: {hits.hits.0._source.geo_shape_0.bbox.1.lon: 110.74218749999999}
 
 # Test Linestring
   - do:


### PR DESCRIPTION
bbox() aggregation does not work on geo_shapes that contain only points

Steps to reproduce:
create a dataset from the attache GeoJSON
the query where=id="point"&select=bbox(geo_shape) returns null bbox ...

I propose here a fix and a test.