### PR TITLE
Add sum_other_doc_count field to geoshape agg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 .idea/
 build/
 .vscode/
+
+# Eclipse
+.classpath
+.project
+.settings/
+bin/

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Result:
 ```
 "aggregations": {
   "geo_preview": {
+    "sum_other_doc_count": 0,
     "buckets": [
       {
         "key": "AAAAAAMAAAABAAAABkAALAAAAAAAQEhMXSKIhts/+uT//////0BIhrDKsBJAQACGAAAAAABASJ2wcvbTDkAGPIAAAAAAQEiZGKALhAxAChqAAAAAAEBIdhR0tDaAQAAsAAAAAABASExdIoiG2w==",
@@ -302,6 +303,10 @@ Result:
   }
 }
 ```
+
+`sum_other_doc_count` is the total number of documents carried by the shapes that are **not** returned (because of `size` or `shard_size`). It is `0` when every shape is returned, and `> 0` when the result is truncated. It is **exact**, including shapes dropped per-shard by `shard_size`, and mirrors the field of the same name on elasticsearch's `terms` aggregation.
+
+Note: because buckets are ranked by perimeter (an intrinsic property of each shape, identical on every shard), `shard_size` does not need to exceed `size` to return the exact top-`size` largest shapes (unlike `terms`, where `shard_size` trades off accuracy).
 
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can find past releases [here](https://github.com/opendatasoft/elasticsearch-
 The first 3 digits of the plugin version is the corresponding Elasticsearch version. The last digit is used for plugin versioning.
 
 To install it, launch this command in Elasticsearch directory replacing the url by the correct link for your Elasticsearch version (see table)
-`bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-plugin-geoshape/releases/download/v8.19.6.0/elasticsearch-plugin-geoshape-8.19.6.0.zip"`
+`bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-plugin-geoshape/releases/download/v8.19.6.1/elasticsearch-plugin-geoshape-8.19.6.1.zip"`
 
 
 ## Build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 elastic_version = 8.19.6
-plugin_version = 8.19.6.0
+plugin_version = 8.19.6.1
 hamcrest_version = 2.1
 junit_version = 4.13.2

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/geoshape/GeoShapeAggregator.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/geoshape/GeoShapeAggregator.java
@@ -137,7 +137,10 @@ public class GeoShapeAggregator extends BucketsAggregator {
                 InternalGeoShape.BucketPriorityQueue ordered = new InternalGeoShape.BucketPriorityQueue(size);
 
                 InternalGeoShape.InternalBucket spare = null;
+                // Total doc count of every distinct shape collected on this shard, before `shard_size` truncation.
+                long totalDocCount = 0;
                 for (int i = 0; i < bucketOrds.size(); i++) {
+                    totalDocCount += bucketDocCount(i);
                     if (spare == null) {
                         spare = new InternalGeoShape.InternalBucket(new BytesRef(), null, null, 0, 0, null);
                     }
@@ -190,12 +193,21 @@ public class GeoShapeAggregator extends BucketsAggregator {
                     topBucketsPerOrd.get(ordIdx)[i] = bucket;
                 }
 
+                // Docs carried by the shapes this shard actually returns; the rest is reported as "other".
+                long returnedDocCount = 0;
+                for (InternalGeoShape.InternalBucket bucket : topBucketsPerOrd.get(ordIdx)) {
+                    if (bucket != null) {
+                        returnedDocCount += bucket.docCount;
+                    }
+                }
+
                 results[Math.toIntExact(ordIdx)] = new InternalGeoShape(
                     name,
                     Arrays.asList(topBucketsPerOrd.get(ordIdx)),
                     output_format,
                     bucketCountThresholds.getRequiredSize(),
                     bucketCountThresholds.getShardSize(),
+                    totalDocCount - returnedDocCount,
                     metadata()
                 );
             }
@@ -214,6 +226,7 @@ public class GeoShapeAggregator extends BucketsAggregator {
             output_format,
             bucketCountThresholds.getRequiredSize(),
             bucketCountThresholds.getShardSize(),
+            0,
             metadata()
         );
     }

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/geoshape/GeoShapeAggregatorFactory.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/geoshape/GeoShapeAggregatorFactory.java
@@ -53,6 +53,7 @@ class GeoShapeAggregatorFactory extends ValuesSourceAggregatorFactory {
             output_format,
             bucketCountThresholds.getRequiredSize(),
             bucketCountThresholds.getShardSize(),
+            0,
             metadata
         );
         return new NonCollectingAggregator(name, context, parent, factories, metadata) {

--- a/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/geoshape/InternalGeoShape.java
+++ b/src/main/java/org/opendatasoft/elasticsearch/search/aggregations/bucket/geoshape/InternalGeoShape.java
@@ -150,6 +150,9 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
     private List<InternalBucket> buckets;
     private final int requiredSize;
     private final int shardSize;
+    // Total doc count of the shapes that are NOT returned (dropped by `size` at the coordinator or by
+    // `shard_size` at the shard). Exact: each shard knows precisely how many docs it dropped.
+    private final long otherDocCount;
     private OutputFormat output_format;
     private GeoJsonWriter geoJsonWriter;
 
@@ -159,6 +162,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
         OutputFormat output_format,
         int requiredSize,
         int shardSize,
+        long otherDocCount,
         Map<String, Object> metadata
     ) {
         super(name, metadata);
@@ -166,6 +170,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
         this.output_format = output_format;
         this.requiredSize = requiredSize;
         this.shardSize = shardSize;
+        this.otherDocCount = otherDocCount;
         geoJsonWriter = new GeoJsonWriter();
     }
 
@@ -177,6 +182,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
         output_format = OutputFormat.valueOf(in.readString());
         requiredSize = readSize(in);
         shardSize = readSize(in);
+        otherDocCount = in.readVLong();
         this.buckets = in.readCollectionAsList(InternalBucket::new);
     }
 
@@ -188,6 +194,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
         out.writeString(output_format.name());
         writeSize(requiredSize, out);
         writeSize(shardSize, out);
+        out.writeVLong(otherDocCount);
         out.writeCollection(buckets);
     }
 
@@ -198,7 +205,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
 
     @Override
     public InternalGeoShape create(List<InternalBucket> buckets) {
-        return new InternalGeoShape(this.name, buckets, output_format, requiredSize, shardSize, this.metadata);
+        return new InternalGeoShape(this.name, buckets, output_format, requiredSize, shardSize, otherDocCount, this.metadata);
     }
 
     @Override
@@ -222,10 +229,13 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
             private LongObjectPagedHashMap<List<InternalBucket>> buckets = new LongObjectPagedHashMap<>(size, reduceContext.bigArrays());
+            // Carry the doc count of shapes already dropped upstream (per-shard `shard_size`, earlier partial reduces).
+            private long otherDocCountSum = 0;
 
             @Override
             public void accept(InternalAggregation aggregation) {
                 InternalGeoShape shape = (InternalGeoShape) aggregation;
+                otherDocCountSum += shape.otherDocCount;
 
                 if (buckets == null) {
                     buckets = new LongObjectPagedHashMap<>(shape.buckets.size(), reduceContext.bigArrays());
@@ -243,20 +253,40 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
 
             @Override
             public InternalAggregation get() {
-                final int size = !reduceContext.isFinalReduce() ? (int) buckets.size() : Math.min(requiredSize, (int) buckets.size());
+                final boolean isFinalReduce = reduceContext.isFinalReduce();
+                final long distinctShapes = buckets.size();
+                final int size = !isFinalReduce ? (int) distinctShapes : Math.min(requiredSize, (int) distinctShapes);
 
                 BucketPriorityQueue ordered = new BucketPriorityQueue(size);
+                long totalDocCount = 0;
                 for (LongObjectPagedHashMap.Cursor<List<InternalBucket>> cursor : buckets) {
                     List<InternalBucket> sameCellBuckets = cursor.value;
-                    ordered.insertWithOverflow(reduceBucket(sameCellBuckets, reduceContext));
+                    InternalBucket reducedBucket = reduceBucket(sameCellBuckets, reduceContext);
+                    totalDocCount += reducedBucket.docCount;
+                    ordered.insertWithOverflow(reducedBucket);
                 }
                 buckets.close();
                 InternalBucket[] list = new InternalBucket[ordered.size()];
+                long returnedDocCount = 0;
                 for (int i = ordered.size() - 1; i >= 0; i--) {
                     list[i] = ordered.pop();
+                    returnedDocCount += list[i].docCount;
                 }
 
-                return new InternalGeoShape(getName(), Arrays.asList(list), output_format, requiredSize, shardSize, getMetadata());
+                // Docs hidden = those dropped upstream + those merged here but dropped by `size`.
+                // At a non-final reduce nothing is dropped by `size` (the queue keeps every shape), so this
+                // just carries otherDocCountSum forward.
+                long reducedOtherDocCount = otherDocCountSum + (totalDocCount - returnedDocCount);
+
+                return new InternalGeoShape(
+                    getName(),
+                    Arrays.asList(list),
+                    output_format,
+                    requiredSize,
+                    shardSize,
+                    reducedOtherDocCount,
+                    getMetadata()
+                );
             }
         };
     }
@@ -278,6 +308,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        builder.field("sum_other_doc_count", otherDocCount);
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (InternalBucket bucket : buckets) {
             builder.startObject();
@@ -298,7 +329,7 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), buckets, output_format, requiredSize, shardSize);
+        return Objects.hash(super.hashCode(), buckets, output_format, requiredSize, shardSize, otherDocCount);
     }
 
     @Override
@@ -311,7 +342,8 @@ public class InternalGeoShape extends InternalMultiBucketAggregation<InternalGeo
         return Objects.equals(buckets, that.buckets)
             && Objects.equals(output_format, that.output_format)
             && Objects.equals(requiredSize, that.requiredSize)
-            && Objects.equals(shardSize, that.shardSize);
+            && Objects.equals(shardSize, that.shardSize)
+            && Objects.equals(otherDocCount, that.otherDocCount);
     }
 
     // The priority queue is used to retain the top N buckets (i.e. shapes)

--- a/src/yamlRestTest/resources/rest-api-spec/test/GeoExtension/40_geoshape_aggregation.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/GeoExtension/40_geoshape_aggregation.yml
@@ -203,3 +203,136 @@
 
   # coordinates length must be 37. it's not possible to test this length because the shape is dumped as a text, so we're testing the full shape length here instead
   - length: {aggregations.g.buckets.1.key: 935}
+
+---
+"Test truncation reporting: sum_other_doc_count":
+
+# Create the pipeline
+  - do:
+      ingest.put_pipeline:
+        id: "geo_extension"
+        body:  >
+          {
+            "description": "Add extra geo fields to geo_shape fields.",
+            "processors": [
+              {
+                "geo_extension": {
+                  "field": "geo_shape_*"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+# Single shard so the shard_size behaviour is deterministic
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_mapping:
+        index: test_index
+        body:
+          dynamic_templates: [
+            {
+              "geo_shapes": {
+                "match": "geo_shape_*",
+                "mapping": {
+                  "properties": {
+                    "shape": {"enabled": false},
+                    "fixed_shape": {"type": "geo_shape"},
+                    "hash": {"type": "keyword"},
+                    "wkb": {"type": "binary", "doc_values": true},
+                    "type": {"type": "keyword"},
+                    "area": {"type": "half_float"},
+                    "bbox": {"type": "geo_point"},
+                    "centroid": {"type": "geo_point"}
+                  }
+                }
+              }
+            }
+          ]
+
+# 3 distinct shapes, 4 docs total:
+#   BIG   (~1 deg perimeter)   x1  -> largest perimeter, returned first
+#   MED   (~0.1 deg perimeter) x2  -> same WKB twice => docCount 2
+#   SMALL (~0.01 deg perimeter)x1
+  - do:
+      index:
+        index: test_index
+        pipeline: "geo_extension"
+        body: { "id": 1, "geo_shape_0": { "type": "Polygon", "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]] } }
+
+  - do:
+      index:
+        index: test_index
+        pipeline: "geo_extension"
+        body: { "id": 2, "geo_shape_0": { "type": "Polygon", "coordinates": [[[0,0],[0.1,0],[0.1,0.1],[0,0.1],[0,0]]] } }
+
+  - do:
+      index:
+        index: test_index
+        pipeline: "geo_extension"
+        body: { "id": 3, "geo_shape_0": { "type": "Polygon", "coordinates": [[[0,0],[0.1,0],[0.1,0.1],[0,0.1],[0,0]]] } }
+
+  - do:
+      index:
+        index: test_index
+        pipeline: "geo_extension"
+        body: { "id": 4, "geo_shape_0": { "type": "Polygon", "coordinates": [[[0,0],[0.01,0],[0.01,0.01],[0,0.01],[0,0]]] } }
+
+  - do:
+      indices.refresh: {}
+
+# size:1, shard_size:10 -> BIG returned; MED & SMALL dropped by `size` at the coordinator.
+#   sum_other_doc_count = 3 docs hidden (MED x2 + SMALL x1)
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            g:
+              geoshape:
+                field: "geo_shape_0.wkb"
+                output_format: geojson
+                size: 1
+                shard_size: 10
+  - length: { aggregations.g.buckets: 1 }
+  - match: { aggregations.g.sum_other_doc_count: 3 }
+  # other_bucket_count was removed: the field must no longer be present
+  - is_false: aggregations.g.other_bucket_count
+
+# size:10, shard_size:10 -> everything fits, nothing hidden
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            g:
+              geoshape:
+                field: "geo_shape_0.wkb"
+                output_format: geojson
+                size: 10
+                shard_size: 10
+  - length: { aggregations.g.buckets: 3 }
+  - match: { aggregations.g.sum_other_doc_count: 0 }
+
+# size:1, shard_size:1 -> the shard itself drops MED & SMALL before reduce.
+#   sum_other_doc_count stays EXACT (3) thanks to per-shard propagation, even though
+#   those shapes never reached the coordinator.
+  - do:
+      search:
+        body:
+          size: 0
+          aggs:
+            g:
+              geoshape:
+                field: "geo_shape_0.wkb"
+                output_format: geojson
+                size: 1
+                shard_size: 1
+  - length: { aggregations.g.buckets: 1 }
+  - match: { aggregations.g.sum_other_doc_count: 3 }


### PR DESCRIPTION
## What

  Adds a `sum_other_doc_count` field to the `geoshape` aggregation response, mirroring elasticsearch's `terms` aggregation.

  ```json
  "geo_preview": {
    "sum_other_doc_count": 3,
    "buckets": [ ... ]
  }
```
  
  It is the exact number of documents carried by shapes that are not returned — whether dropped by size at the coordinating node or by shard_size at the shard (each shard propagates what it dropped). So sum_other_doc_count > 0 is a reliable signal that a query (e.g. a vector tile) is truncating its shapes.

## Why

  There was no way to tell, from a response, whether size hid some shapes. This is the standard terms mechanism, adapted to this aggregation.


## How to test
Install the plugin using the following zip (commit [432e136](https://github.com/opendatasoft/elasticsearch-plugin-geoshape/pull/22/commits/432e136e855bd67dfb442208d2c429e791691421)):
[elasticsearch-plugin-geoshape-8.19.6.1.zip](https://github.com/user-attachments/files/28719106/elasticsearch-plugin-geoshape-8.19.6.1.zip)

If you're running Elasticsearch from docker:
```sh
docker compose exec -u root elasticsearch elasticsearch-plugin remove elasticsearch-plugin-geoshape
docker compose exec -u root elasticsearch elasticsearch-plugin install https://github.com/user-attachments/files/28719106/elasticsearch-plugin-geoshape-8.19.6.1.zip
docker compose restart elasticsearch
```
